### PR TITLE
Fix for issue #23 error: cannot find symbol import com.newrelic.agent.android.analytics.AnalyticAttribute 

### DIFF
--- a/hooks/android/android.js
+++ b/hooks/android/android.js
@@ -28,9 +28,9 @@ module.exports = {
   /**
    * Agent build extension
    */
-  nrTag: "\n// NEWRELIC ADDED\n" 
+  nrTag: "\n// NEWRELIC ADDED\n"
     + "buildscript {\n\tdependencies {\n\t\tclasspath 'com.newrelic.agent.android:agent-gradle-plugin:{AGENT_VER}'\n\t}\n}\n"
-    + "dependencies {\n\tcompile ('com.newrelic.agent.android:android-agent:{AGENT_VER}')\n}\n"
+    + "dependencies {\n\implementation 'com.newrelic.agent.android:android-agent:{AGENT_VER}'\n}\n"
     + "{PLUGIN}"
     + "// NEWRELIC ADDED\n",
 
@@ -85,7 +85,7 @@ module.exports = {
   /**
    * Return {boolean} - if this platform exists and has been configured with an application token
    */
-  isPlatformConfigured: function() {
+  isPlatformConfigured: function () {
     var config = newrelic.getAndroidConfig();
     return newrelic.isPlatformConfigured(config);
   },


### PR DESCRIPTION
There you have to remove the line starting with compile for agent and replace as shown below

nrTag: "\n// NEWRELIC ADDED\n"

"buildscript {\n\tdependencies {\n\t\tclasspath 'com.newrelic.agent.android:agent-gradle-plugin:{AGENT_VER}'\n\t}\n}\n"
"dependencies {\n\implementation 'com.newrelic.agent.android:android-agent:{AGENT_VER}'\n}\n"
"{PLUGIN}"
"// NEWRELIC ADDED\n",
reference can be found under link ->
https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-android/install-configure/install-new-relic-plugin-android-instant-apps

where in example it shows
implementation "com.newrelic.agent.android:android-agent:${project.agentVersion}"
instead of using compile